### PR TITLE
Add bearer token auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,5 +59,12 @@
             <version>2.4.3</version>
         </dependency>
 
+        <!-- JsonPath: easy querying and manipulation of JSON data -->
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/src/test/java/com/ecossio7/ParticipantsTests.java
+++ b/src/test/java/com/ecossio7/ParticipantsTests.java
@@ -17,7 +17,8 @@ public class ParticipantsTests extends BaseTest {
     private ParticipantsRequests participantsRequests;
 
     @BeforeEach
-    void setUp(APIRequestContext apiRequestContext) {
+    void setUp(APIRequestContext apiRequestContext) throws IOException {
+        initOAuth2(apiRequestContext, requestOptions);
         participantsRequests = new ParticipantsRequests(apiRequestContext);
     }
 

--- a/src/test/java/com/ecossio7/VideoJuegosTests.java
+++ b/src/test/java/com/ecossio7/VideoJuegosTests.java
@@ -17,7 +17,8 @@ public class VideoJuegosTests extends BaseTest {
     private VideoJuegoRequests videoJuegoRequests;
 
     @BeforeEach
-    void setUp(APIRequestContext apiRequestContext) {
+    void setUp(APIRequestContext apiRequestContext) throws IOException {
+        initOAuth2(apiRequestContext, requestOptions);
         videoJuegoRequests = new VideoJuegoRequests(apiRequestContext);
     }
 

--- a/src/test/java/requests/LoginRequests.java
+++ b/src/test/java/requests/LoginRequests.java
@@ -1,0 +1,22 @@
+package requests;
+
+import com.microsoft.playwright.APIRequestContext;
+import com.microsoft.playwright.APIResponse;
+import com.microsoft.playwright.options.RequestOptions;
+import utilities.ApiLogger;
+import utilities.BaseRequest;
+import utilities.BaseTest;
+
+
+public class LoginRequests extends BaseRequest {
+    public LoginRequests(APIRequestContext apiRequestContext) {
+        super(apiRequestContext);
+    }
+
+    public APIResponse login(RequestOptions requestOptions) {
+        apiResponse = apiRequestContext.post("login", requestOptions);
+        ApiLogger.logApi(apiResponse, BaseTest.Method.POST);
+        return apiResponse;
+    }
+
+}

--- a/src/test/java/utilities/BaseTest.java
+++ b/src/test/java/utilities/BaseTest.java
@@ -1,10 +1,17 @@
 package utilities;
 
 import com.google.gson.Gson;
+import com.jayway.jsonpath.JsonPath;
+import com.microsoft.playwright.APIRequestContext;
 import com.microsoft.playwright.APIResponse;
 import com.microsoft.playwright.junit.UsePlaywright;
 import com.microsoft.playwright.options.RequestOptions;
 import org.junit.jupiter.api.BeforeEach;
+import requests.LoginRequests;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @UsePlaywright(CustomOptions.class)
 public class BaseTest {
@@ -24,5 +31,17 @@ public class BaseTest {
         PUT,
         PATCH,
         DELETE
+    }
+
+    public void initOAuth2(APIRequestContext apiRequestContext, RequestOptions requestOptions) throws IOException {
+        Logs.info("initOAuth2: Placeholder for OAuth2 initialization logic");
+        final var body = Files.readAllBytes(Paths.get("src/test/resources/user.json"));
+        requestOptions.setData(body);
+        requestOptions.setHeader("Content-Type", "application/json; charset=utf-8");
+        LoginRequests loginRequests = new LoginRequests(apiRequestContext);
+        apiResponse = loginRequests.login(requestOptions);
+        final var json = JsonPath.parse(apiResponse.text());
+        final var token = json.read("accessToken", String.class);
+        requestOptions.setHeader("Authorization", "Bearer " + token);
     }
 }

--- a/src/test/java/utilities/CustomOptions.java
+++ b/src/test/java/utilities/CustomOptions.java
@@ -13,7 +13,7 @@ public class CustomOptions implements OptionsFactory {
      */
     @Override
     public Options getOptions() {
-        APIRequest.NewContextOptions apiRequestOptions = buildApiRequestOptions();
+        APIRequest.NewContextOptions apiRequestOptions = buildApiRequestOptionsOAuth2();
 
         // Create Options object and set the prepared API request options
         Options options = new Options();
@@ -36,5 +36,11 @@ public class CustomOptions implements OptionsFactory {
         requestOptions.setExtraHTTPHeaders(Map.of("Content-Type", "application/json"));
 
         return requestOptions;
+    }
+
+    private APIRequest.NewContextOptions buildApiRequestOptionsOAuth2() {
+        APIRequest.NewContextOptions options = new APIRequest.NewContextOptions();
+        options.setBaseURL("http://127.0.0.1:3000/auth/");
+        return options;
     }
 }

--- a/src/test/resources/user.json
+++ b/src/test/resources/user.json
@@ -1,0 +1,4 @@
+{
+  "username": "standard_user",
+  "password": "secret_blass_academy"
+}


### PR DESCRIPTION
Enhancements for OAuth 2.0 integration and test login automation:

Added json-path dependency in pom.xml to extract access tokens from login responses.

Updated base URL in CustomOptions.java to support OAuth 2.0 endpoints.

Added initOAuth2 method in BaseTest.java to set the Authorization header dynamically using a bearer token.

Added new login request handler in src/test/java/requests/LoginRequests.java.

Updated setup logic in test classes to perform login automatically and include the token in API requests for:

ParticipantsTests.java

VideoJuegosTests.java