### PR TITLE
Add api test cases unhappy path for videojuego and participants

### DIFF
--- a/src/test/java/com/ecossio7/participants/ParticipantsEmptyTests.java
+++ b/src/test/java/com/ecossio7/participants/ParticipantsEmptyTests.java
@@ -1,0 +1,52 @@
+package com.ecossio7.participants;
+
+import com.microsoft.playwright.APIRequestContext;
+import models.RError;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import requests.ParticipantsRequests;
+import utilities.BaseTest;
+
+import java.io.IOException;
+
+public class ParticipantsEmptyTests extends BaseTest {
+    private ParticipantsRequests participantsRequests;
+
+    @BeforeEach
+    void setUp(APIRequestContext apiRequestContext) throws IOException {
+        initOAuth2(apiRequestContext, requestOptions);
+        participantsRequests = new ParticipantsRequests(apiRequestContext);
+    }
+
+
+    @Test
+    void createParticipantTest() {
+        final var body = "{}";
+        requestOptions.setData(body);
+        apiResponse = participantsRequests.create(requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(400, apiResponse.status());
+        Assertions.assertEquals("Debe especificar un payload", actualError.mensaje());
+    }
+
+    @Test
+    void updateParticipantTest() {
+        final var body = "{}";
+        requestOptions.setData(body);
+        apiResponse = participantsRequests.update(5, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(400, apiResponse.status());
+        Assertions.assertEquals("Debe especificar un payload", actualError.mensaje());
+    }
+
+    @Test
+    void partialParticipantTest() {
+        final var body = "{}";
+        requestOptions.setData(body);
+        apiResponse = participantsRequests.partialUpdate(5, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(400, apiResponse.status());
+        Assertions.assertEquals("Debe especificar un payload", actualError.mensaje());
+    }
+}

--- a/src/test/java/com/ecossio7/participants/ParticipantsNoAuthTests.java
+++ b/src/test/java/com/ecossio7/participants/ParticipantsNoAuthTests.java
@@ -1,0 +1,117 @@
+package com.ecossio7.participants;
+
+import com.google.gson.JsonParser;
+import com.microsoft.playwright.APIRequestContext;
+import models.RError;
+import models.RParticipant;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import requests.ParticipantsRequests;
+import utilities.BaseTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class ParticipantsNoAuthTests extends BaseTest {
+    private ParticipantsRequests participantsRequests;
+
+    @BeforeEach
+    void setUp(APIRequestContext apiRequestContext) throws IOException {
+        participantsRequests = new ParticipantsRequests(apiRequestContext);
+    }
+
+    @Test
+    void getAllParticipantsTest() {
+        apiResponse = participantsRequests.getAll(requestOptions);
+        Assertions.assertEquals(401, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("No autorizado", error.mensaje());
+    }
+
+    @Test
+    void findParticipantTest() {
+        requestOptions.setQueryParam("nombre", "Will");
+        apiResponse = participantsRequests.getAll(requestOptions);
+        Assertions.assertEquals(401, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("No autorizado", error.mensaje());
+    }
+
+    @Test
+    void sortParticipantsTest() {
+        requestOptions.setQueryParam("sortBy", "dislikes");
+        requestOptions.setQueryParam("order", "asc");
+        apiResponse = participantsRequests.getAll(requestOptions);
+        Assertions.assertEquals(401, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("No autorizado", error.mensaje());
+    }
+
+    @Test
+    void filterParticipantsTest() {
+        requestOptions.setQueryParam("filterBy", "plataforma");
+        requestOptions.setQueryParam("value", "tiktok");
+        apiResponse = participantsRequests.getAll(requestOptions);
+        Assertions.assertEquals(401, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("No autorizado", error.mensaje());
+    }
+
+    @Test
+    void getParticipantTest() {
+        apiResponse = participantsRequests.getById(20, requestOptions);
+        Assertions.assertEquals(401, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("No autorizado", error.mensaje());
+    }
+
+    @Test
+    void createParticipantTest() {
+        final var participant = RParticipant.generateRParticipant();
+        final var jsonString = gson.toJson(participant);
+        final var jsonObject = JsonParser.parseString(jsonString).getAsJsonObject();
+        jsonObject.remove(("id"));
+
+        requestOptions.setData(jsonObject);
+        apiResponse = participantsRequests.create(requestOptions);
+        Assertions.assertEquals(401, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("No autorizado", error.mensaje());
+    }
+
+    @Test
+    void updateParticipantTest() throws IOException {
+        final var body = Files.readAllBytes(Paths.get("src/test/resources/participant.json"));
+        requestOptions.setData(body);
+        apiResponse = participantsRequests.update(5, requestOptions);
+        Assertions.assertEquals(401, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("No autorizado", error.mensaje());
+    }
+
+    @Test
+    void partialParticipantTest() {
+        String body = """
+                {
+                    "nombre": "partial-updated-nombre",
+                    "apellido": "partial-updated-apellido",
+                    "correo": "partial-update@gmail.com"
+                }
+                """;
+        requestOptions.setData(body);
+        apiResponse = participantsRequests.partialUpdate(5, requestOptions);
+        Assertions.assertEquals(401, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("No autorizado", error.mensaje());
+    }
+
+    @Test
+    void deleteParticipantTest() {
+        apiResponse = participantsRequests.delete(5, requestOptions);
+        Assertions.assertEquals(401, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("No autorizado", error.mensaje());
+    }
+}

--- a/src/test/java/com/ecossio7/participants/ParticipantsNotFoundTests.java
+++ b/src/test/java/com/ecossio7/participants/ParticipantsNotFoundTests.java
@@ -1,0 +1,66 @@
+package com.ecossio7.participants;
+
+import com.microsoft.playwright.APIRequestContext;
+import models.RError;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import requests.ParticipantsRequests;
+import utilities.BaseTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class ParticipantsNotFoundTests extends BaseTest {
+    private ParticipantsRequests participantsRequests;
+
+    @BeforeEach
+    void setUp(APIRequestContext apiRequestContext) throws IOException {
+        initOAuth2(apiRequestContext, requestOptions);
+        participantsRequests = new ParticipantsRequests(apiRequestContext);
+    }
+
+    @Test
+    void getParticipantTest() {
+        apiResponse = participantsRequests.getById(5000, requestOptions);
+        Assertions.assertEquals(404, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("Participante con id 5000 no encontrado", error.mensaje());
+
+    }
+
+    @Test
+    void updateParticipantTest() throws IOException {
+        final var body = Files.readAllBytes(Paths.get("src/test/resources/participant.json"));
+        requestOptions.setData(body);
+        apiResponse = participantsRequests.update(5000, requestOptions);
+        Assertions.assertEquals(404, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("Participante con id 5000 no encontrado", error.mensaje());
+    }
+
+    @Test
+    void partialParticipantTest() {
+        String body = """
+                {
+                    "nombre": "partial-updated-nombre",
+                    "apellido": "partial-updated-apellido",
+                    "correo": "partial-update@gmail.com"
+                }
+                """;
+        requestOptions.setData(body);
+        apiResponse = participantsRequests.partialUpdate(5000, requestOptions);
+        Assertions.assertEquals(404, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("Participante con id 5000 no encontrado", error.mensaje());
+    }
+
+    @Test
+    void deleteParticipantTest() {
+        apiResponse = participantsRequests.delete(5000, requestOptions);
+        Assertions.assertEquals(404, apiResponse.status());
+        final var error = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals("Participante con id 5000 no encontrado", error.mensaje());
+    }
+}

--- a/src/test/java/com/ecossio7/participants/ParticipantsTests.java
+++ b/src/test/java/com/ecossio7/participants/ParticipantsTests.java
@@ -1,4 +1,4 @@
-package com.ecossio7;
+package com.ecossio7.participants;
 
 import com.google.gson.JsonParser;
 import com.microsoft.playwright.APIRequestContext;

--- a/src/test/java/com/ecossio7/videojuegos/VideoJuegosEmptyTests.java
+++ b/src/test/java/com/ecossio7/videojuegos/VideoJuegosEmptyTests.java
@@ -1,0 +1,51 @@
+package com.ecossio7.videojuegos;
+
+import com.microsoft.playwright.APIRequestContext;
+import models.RError;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import requests.VideoJuegoRequests;
+import utilities.BaseTest;
+
+import java.io.IOException;
+
+public class VideoJuegosEmptyTests extends BaseTest {
+    private VideoJuegoRequests videoJuegoRequests;
+
+    @BeforeEach
+    void setUp(APIRequestContext apiRequestContext) throws IOException {
+        initOAuth2(apiRequestContext, requestOptions);
+        videoJuegoRequests = new VideoJuegoRequests(apiRequestContext);
+    }
+
+    @Test
+    void createVideoJuegoTest() {
+        final var body = "{}";
+        requestOptions.setData(body);
+        apiResponse = videoJuegoRequests.create(requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(400, apiResponse.status());
+        Assertions.assertEquals("Debe especificar un payload", actualError.mensaje());
+    }
+
+    @Test
+    void updateVideoJuegoTest() {
+        final var body = "{}";
+        requestOptions.setData(body);
+        apiResponse = videoJuegoRequests.update(5, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(400, apiResponse.status());
+        Assertions.assertEquals("Debe especificar un payload", actualError.mensaje());
+    }
+
+    @Test
+    void partialVideoJuegoTest() {
+        final var body = "{}";
+        requestOptions.setData(body);
+        apiResponse = videoJuegoRequests.partialUpdate(5, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(400, apiResponse.status());
+        Assertions.assertEquals("Debe especificar un payload", actualError.mensaje());
+    }
+}

--- a/src/test/java/com/ecossio7/videojuegos/VideoJuegosNoAuthTests.java
+++ b/src/test/java/com/ecossio7/videojuegos/VideoJuegosNoAuthTests.java
@@ -1,0 +1,118 @@
+package com.ecossio7.videojuegos;
+
+import com.google.gson.JsonParser;
+import com.microsoft.playwright.APIRequestContext;
+import models.RError;
+import models.RVideoJuego;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import requests.VideoJuegoRequests;
+import utilities.BaseTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class VideoJuegosNoAuthTests extends BaseTest {
+    private VideoJuegoRequests videoJuegoRequests;
+
+    @BeforeEach
+    void setUp(APIRequestContext apiRequestContext) throws IOException {
+        videoJuegoRequests = new VideoJuegoRequests(apiRequestContext);
+    }
+
+    @Test
+    void getAllVideoJuegosTest() {
+        apiResponse = videoJuegoRequests.getAll(requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(401, apiResponse.status());
+        Assertions.assertEquals("No autorizado", actualError.mensaje());
+    }
+
+    @Test
+    void findVideoJuegoTest() {
+        requestOptions.setQueryParam("nombre", "Pac-Man");
+        apiResponse = videoJuegoRequests.getAll(requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(401, apiResponse.status());
+        Assertions.assertEquals("No autorizado", actualError.mensaje());
+    }
+
+    @Test
+    void sortVideoJuegosTest() {
+        requestOptions.setQueryParam("sortBy", "epoca");
+        requestOptions.setQueryParam("order", "asc");
+        apiResponse = videoJuegoRequests.getAll(requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(401, apiResponse.status());
+        Assertions.assertEquals("No autorizado", actualError.mensaje());
+    }
+
+    @Test
+    void filterVideoJuegosTest() {
+        requestOptions.setQueryParam("filterBy", "genero");
+        requestOptions.setQueryParam("value", "comedia");
+        apiResponse = videoJuegoRequests.getAll(requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(401, apiResponse.status());
+        Assertions.assertEquals("No autorizado", actualError.mensaje());
+    }
+
+    @Test
+    void getVideoJuegoTest() {
+        apiResponse = videoJuegoRequests.getById(25, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(401, apiResponse.status());
+        Assertions.assertEquals("No autorizado", actualError.mensaje());
+    }
+
+    @Test
+    void createVideoJuegoTest() {
+        final var participant = RVideoJuego.generateVideoJuego();
+        final var jsonString = gson.toJson(participant);
+        final var jsonObject = JsonParser.parseString(jsonString).getAsJsonObject();
+        jsonObject.remove(("id"));
+        requestOptions.setData(jsonObject);
+        apiResponse = videoJuegoRequests.create(requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(401, apiResponse.status());
+        Assertions.assertEquals("No autorizado", actualError.mensaje());
+    }
+
+    @Test
+    void updateVideoJuegoTest() throws IOException {
+        final var body = Files.readAllBytes(Paths.get("src/test/resources/videoJuego.json"));
+        requestOptions.setData(body);
+        apiResponse = videoJuegoRequests.update(5, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(401, apiResponse.status());
+        Assertions.assertEquals("No autorizado", actualError.mensaje());
+    }
+
+    @Test
+    void partialVideoJuegoTest() {
+        final var body = """
+                {
+                    "nombre": "partial-Blass",
+                    "epoca": 2024,
+                    "precio": 31.3,
+                    "duracion": 7,
+                    "genero": "partial-accion"
+                }
+                """;
+        requestOptions.setData(body);
+        apiResponse = videoJuegoRequests.partialUpdate(5, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(401, apiResponse.status());
+        Assertions.assertEquals("No autorizado", actualError.mensaje());
+    }
+
+    @Test
+    void deleteVideoJuegoTest() {
+        apiResponse = videoJuegoRequests.delete(5, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(401, apiResponse.status());
+        Assertions.assertEquals("No autorizado", actualError.mensaje());
+    }
+}

--- a/src/test/java/com/ecossio7/videojuegos/VideoJuegosNotFoundTests.java
+++ b/src/test/java/com/ecossio7/videojuegos/VideoJuegosNotFoundTests.java
@@ -1,0 +1,68 @@
+package com.ecossio7.videojuegos;
+
+import com.microsoft.playwright.APIRequestContext;
+import models.RError;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import requests.VideoJuegoRequests;
+import utilities.BaseTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class VideoJuegosNotFoundTests extends BaseTest {
+    private VideoJuegoRequests videoJuegoRequests;
+
+    @BeforeEach
+    void setUp(APIRequestContext apiRequestContext) throws IOException {
+        initOAuth2(apiRequestContext, requestOptions);
+        videoJuegoRequests = new VideoJuegoRequests(apiRequestContext);
+    }
+
+    @Test
+    void getVideoJuegoTest() {
+        apiResponse = videoJuegoRequests.getById(5000, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(404, apiResponse.status());
+        Assertions.assertEquals("Videojuego con id 5000 no encontrado", actualError.mensaje());
+    }
+
+
+    @Test
+    void updateVideoJuegoTest() throws IOException {
+        final var body = Files.readAllBytes(Paths.get("src/test/resources/videoJuego.json"));
+        requestOptions.setData(body);
+        apiResponse = videoJuegoRequests.update(5000, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(404, apiResponse.status());
+        Assertions.assertEquals("Videojuego con id 5000 no encontrado", actualError.mensaje());
+    }
+
+    @Test
+    void partialVideoJuegoTest() {
+        final var body = """
+                {
+                    "nombre": "partial-Blass",
+                    "epoca": 2024,
+                    "precio": 31.3,
+                    "duracion": 7,
+                    "genero": "partial-accion"
+                }
+                """;
+        requestOptions.setData(body);
+        apiResponse = videoJuegoRequests.partialUpdate(5000, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(404, apiResponse.status());
+        Assertions.assertEquals("Videojuego con id 5000 no encontrado", actualError.mensaje());
+    }
+
+    @Test
+    void deleteVideoJuegoTest() {
+        apiResponse = videoJuegoRequests.delete(5000, requestOptions);
+        final var actualError = gson.fromJson(apiResponse.text(), RError.class);
+        Assertions.assertEquals(404, apiResponse.status());
+        Assertions.assertEquals("Videojuego con id 5000 no encontrado", actualError.mensaje());
+    }
+}

--- a/src/test/java/com/ecossio7/videojuegos/VideoJuegosTests.java
+++ b/src/test/java/com/ecossio7/videojuegos/VideoJuegosTests.java
@@ -1,4 +1,4 @@
-package com.ecossio7;
+package com.ecossio7.videojuegos;
 
 import com.google.gson.JsonParser;
 import com.microsoft.playwright.APIRequestContext;

--- a/src/test/java/models/RError.java
+++ b/src/test/java/models/RError.java
@@ -1,0 +1,4 @@
+package models;
+
+public record RError(String mensaje) {
+}


### PR DESCRIPTION
The following test cases are added:
STATUS CODE 400
 src/test/java/com/ecossio7/participants/ParticipantsEmptyTests.java
 src/test/java/com/ecossio7/videojuegos/VideoJuegosEmptyTests.java
STATUS CODE  401
src/test/java/com/ecossio7/participants/ParticipantsNoAuthTests.java
src/test/java/com/ecossio7/videojuegos/VideoJuegosNoAuthTests.java
STATUS CODE  404
src/test/java/com/ecossio7/participants/ParticipantsNotFoundTests.java        src/test/java/com/ecossio7/videojuegos/VideoJuegosNotFoundTests.java
